### PR TITLE
feat: add mcp() hook with @modelcontextprotocol/server-postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for PostgreSQL: CLI tools (`pgcli`, `pgformatter`, `pg_top`),
+prompt integration, and MCP server (`@modelcontextprotocol/server-postgres` via npm)
+for AI-driven database querying and schema exploration.
 
 ## Contributing
 
@@ -40,8 +42,9 @@ TODO: Add a short summary of this module.
 - `p6df::modules::pgsql::home::symlink()`
 - `p6df::modules::pgsql::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
+- `p6df::modules::pgsql::mcp()`
 - `str str = p6df::modules::pgsql::prompt::lang()`
 
 #### p6df-pgsql/lib

--- a/init.zsh
+++ b/init.zsh
@@ -78,7 +78,7 @@ p6df::modules::pgsql::init() {
 #
 # Function: p6df::modules::pgsql::home::symlink()
 #
-#  Environment:	 P6_DFZ_DATA_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::pgsql::home::symlink() {
@@ -147,3 +147,17 @@ p6df::modules::pgsql::prompt::lang() {
 #  log_lock_waits = on
 #  log_temp_files = 0
 #  lc_messages = 'C'
+
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::mcp()
+#
+#>
+######################################################################
+p6df::modules::pgsql::mcp() {
+
+  p6_js_npm_global_install "@modelcontextprotocol/server-postgres"
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::pgsql::mcp()` installing `@modelcontextprotocol/server-postgres` via npm
- Regenerated README with updated function list
- Restored Summary section

## Test plan
- [ ] `p6df::modules::pgsql::mcp()` installs the official postgres MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)