### PR TITLE
feat: upgrade to postgresql@18 and harden CI workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,12 +9,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  pull-requests: write
 
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
     steps:
       - name: Skip on queue refs
         if: github.event_name == 'merge_group' || github.event_name == 'push'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -9,12 +9,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  pull-requests: write
 
 jobs:
   codex-review:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
     steps:
       - name: Skip on queue refs
         if: github.event_name == 'merge_group' || github.event_name == 'push'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: PR Labeler
+name: Stale
 
 on:
   workflow_dispatch: {}

--- a/init.zsh
+++ b/init.zsh
@@ -23,25 +23,17 @@ p6df::modules::pgsql::deps() {
 ######################################################################
 p6df::modules::pgsql::external::brew() {
 
-  local ver
-#  for ver in 13 14 15 16; do
-#    p6df::core::homebrew::cli::brew::install postgresql@$ver
-#  done
+  p6df::core::homebrew::cli::brew::install postgresql@18
 
-
-# p6df::core::homebrew::cli::brew::install pgrouting
-#  p6df::core::homebrew::cli::brew::install postgis
-
-  p6df::core::homebrew::cli::brew::install pg_top
-#  p6df::core::homebrew::cli::brew::install pgbadger
-#  p6df::core::homebrew::cli::brew::install pgbouncer
   p6df::core::homebrew::cli::brew::install pgcli
   p6df::core::homebrew::cli::brew::install pgformatter
   p6df::core::homebrew::cli::brew::install pgpdump
-  p6df::core::homebrew::cli::brew::install pgtoolkit
-
   p6df::core::homebrew::cli::brew::install check_postgres
 
+#  p6df::core::homebrew::cli::brew::install pgrouting
+#  p6df::core::homebrew::cli::brew::install postgis
+#  p6df::core::homebrew::cli::brew::install pgbadger
+#  p6df::core::homebrew::cli::brew::install pgbouncer
 #  p6df::core::homebrew::cli::brew::install --cask pgadmin4
 #  p6df::core::homebrew::cli::brew::install --cask postico
 #  p6df::core::homebrew::cli::brew::install --cask dbeaver-community
@@ -68,7 +60,7 @@ p6df::modules::pgsql::init() {
 
   p6_bootstrap "$dir"
 
-  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@14"
+  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@18"
   p6_env_export "PKG_CONFIG_PATH" "$postgres_dir/lib/pkgconfig"
   p6_path_if "$postgres_dir/bin"
 
@@ -127,25 +119,25 @@ p6df::modules::pgsql::prompt::lang() {
 }
 
 # This formula has created a default database cluster with:
-#  initdb --locale=C -E UTF-8 /opt/homebrew/var/postgresql@14
+#  initdb --locale=C -E UTF-8 /opt/homebrew/var/postgresql@18
 # For more details, read:
-#  https://www.postgresql.org/docs/14/app-initdb.html
+#  https://www.postgresql.org/docs/18/app-initdb.html
 #
-# postgresql@14 is keg-only, which means it was not symlinked into /opt/homebrew,
+# postgresql@18 is keg-only, which means it was not symlinked into /opt/homebrew,
 # because this is an alternate version of another formula.
 #
-# If you need to have postgresql@14 first in your PATH, run:
-#  echo 'export PATH="/opt/homebrew/opt/postgresql@14/bin:$PATH"' >> ~/.zshrc
+# If you need to have postgresql@18 first in your PATH, run:
+#  echo 'export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"' >> ~/.zshrc
 #
-# For compilers to find postgresql@14 you may need to set:
-#  export LDFLAGS="-L/opt/homebrew/opt/postgresql@14/lib"
-# For pkg-config to find postgresql@14 you may need to set:
-#  export PKG_CONFIG_PATH="/opt/homebrew/opt/postgresql@14/lib/pkgconfig"
+# For compilers to find postgresql@18 you may need to set:
+#  export LDFLAGS="-L/opt/homebrew/opt/postgresql@18/lib"
+# For pkg-config to find postgresql@18 you may need to set:
+#  export PKG_CONFIG_PATH="/opt/homebrew/opt/postgresql@18/lib/pkgconfig"
 #
-# To start postgresql@14 now and restart at login:
-#  brew services start postgresql@14
+# To start postgresql@18 now and restart at login:
+#  brew services start postgresql@18
 # Or, if you don't want/need a background service you can just run:
-#  LC_ALL="C" /opt/homebrew/opt/postgresql@14/bin/postgres -D /opt/homebrew/var/postgresql@14
+#  LC_ALL="C" /opt/homebrew/opt/postgresql@18/bin/postgres -D /opt/homebrew/var/postgresql@18
 
 # To have launchd start pgbouncer now and restart at login:
 #   brew services start pgbouncer

--- a/init.zsh
+++ b/init.zsh
@@ -93,6 +93,24 @@ p6df::modules::pgsql::home::symlink() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::pgsql::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::pgsql::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres"                                           "$HOME/.claude/skills/neon-postgres"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres-egress-optimizer"                         "$HOME/.claude/skills/neon-postgres-egress-optimizer"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/claimable-postgres"                                     "$HOME/.claude/skills/claimable-postgres"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/supabase/agent-skills/skills/supabase-postgres-best-practices"                           "$HOME/.claude/skills/supabase-postgres-best-practices"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: str str = p6df::modules::pgsql::prompt::lang()
 #
 #  Returns:

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -8,7 +8,7 @@
 ######################################################################
 p6df::modules::pgsql::cli::start() {
 
-  LC_ALL="C" /opt/homebrew/opt/postgresql@14/bin/postgres -D /opt/homebrew/var/postgresql@14 start
+  LC_ALL="C" /opt/homebrew/opt/postgresql@18/bin/postgres -D /opt/homebrew/var/postgresql@18 start
 
   p6_return_void
 }
@@ -22,7 +22,7 @@ p6df::modules::pgsql::cli::start() {
 ######################################################################
 p6df::modules::pgsql::cli::stop() {
 
-  LC_ALL="C" /opt/homebrew/opt/postgresql@14/bin/postgres -D /opt/homebrew/var/postgresql@14 stop
+  LC_ALL="C" /opt/homebrew/opt/postgresql@18/bin/postgres -D /opt/homebrew/var/postgresql@18 stop
  
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Upgrade all `postgresql@14` references to `postgresql@18` across `init.zsh`, `lib/cli.sh`, and inline comments
- Remove `pg_top` and `pgtoolkit` (both have limited upstream activity and unverified pg18 compatibility)
- Add `home::symlinks()` for Claude agent skills (neon, claimable-postgres, supabase)

## CI Workflow Fixes

- Scope `id-token: write` permission to job level in `claude-review.yml` and `codex-review.yml` (was incorrectly at workflow level — least-privilege fix)
- Fix `stale.yml` workflow name (was `PR Labeler`, now `Stale`)

## Test plan

- [ ] Run `p6df::modules::pgsql::external::brew` on macOS with Homebrew to verify `postgresql@18` installs cleanly
- [ ] Verify `p6df::modules::pgsql::init` correctly adds `postgresql@18` to `PATH` and `PKG_CONFIG_PATH`
- [ ] Confirm `lib/cli.sh` start/stop commands work against the pg18 data directory
- [ ] Validate GitHub Actions workflows pass actionlint (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)