### PR TITLE
chore(pgsql): merge home::symlink into home::symlinks, fix .psqlrc typo

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -70,27 +70,14 @@ p6df::modules::pgsql::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::pgsql::home::symlink()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::pgsql::home::symlink() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-pgsql/share/.pgsqlrc" "$HOME/.pgsqlrc"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::pgsql::home::symlinks()
 #
-#  Environment:	 HOME P6_DFZ_SRC_DIR
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::pgsql::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-pgsql/share/.psqlrc" "$HOME/.psqlrc"
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres"                                           "$HOME/.claude/skills/neon-postgres"
   p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres-egress-optimizer"                         "$HOME/.claude/skills/neon-postgres-egress-optimizer"


### PR DESCRIPTION
## What
Merge the dotfile symlink from singular (never-called) `home::symlink` into plural (auto-called) `home::symlinks`. Fix `.pgsqlrc` → `.psqlrc` typo. Delete singular function.

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The singular function was never auto-called. The target was incorrectly named `.pgsqlrc` instead of `.psqlrc`.

## Test plan
- `p6df home symlinks` recreates `~/.psqlrc` and all claude skills symlinks

## Dependencies
None