### PR TITLE
fix(pgsql): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -187,6 +187,6 @@ p6df::modules::pgsql::mcp() {
 ######################################################################
 p6df::modules::pgsql::profile::mod() {
 
-  p6_return_words 'pgsql' "$PGHOST"
+  p6_return_words 'pgsql' '$PGHOST'
 }
 


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None