### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::deps()
+#
+#>
+######################################################################
 p6df::modules::pgsql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6pgsql
@@ -8,6 +14,13 @@ p6df::modules::pgsql::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::env::init()
+#
+#  Environment:	 HOMEBREW_PREFIX PKG_CONFIG_PATH
+#>
 ######################################################################
 p6df::modules::pgsql::env::init() {
 
@@ -20,6 +33,13 @@ p6df::modules::pgsql::env::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::path::init()
+#
+#  Environment:	 HOMEBREW_PREFIX
+#>
+######################################################################
 p6df::modules::pgsql::path::init() {
 
   local _module="$1"
@@ -30,6 +50,13 @@ p6df::modules::pgsql::path::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::pgsql::home::symlinks() {
 
@@ -42,6 +69,12 @@ p6df::modules::pgsql::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::pgsql::external::brews() {
 
@@ -65,6 +98,12 @@ p6df::modules::pgsql::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::mcp()
+#
+#>
+######################################################################
 p6df::modules::pgsql::mcp() {
 
   p6_js_npm_global_install "@modelcontextprotocol/server-postgres"
@@ -76,44 +115,21 @@ p6df::modules::pgsql::mcp() {
 }
 
 ######################################################################
+#<
+#
+# Function: words pgsql $PGHOST = p6df::modules::pgsql::profile::mod()
+#
+#  Returns:
+#	words - pgsql $PGHOST
+#
+#  Environment:	 PGHOST
+#>
+######################################################################
 p6df::modules::pgsql::profile::mod() {
 
   p6_return_words 'pgsql' '$PGHOST'
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::env::init()
-#
-#  Environment:	 HOMEBREW_PREFIX PKG_CONFIG_PATH
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::path::init()
-#
-#  Environment:	 HOMEBREW_PREFIX
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
 ######################################################################
 #<
 #
@@ -174,19 +190,3 @@ p6df::modules::pgsql::prompt::lang() {
 #  log_temp_files = 0
 #  lc_messages = 'C'
 
-######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::mcp()
-#
-#>
-######################################################################
-#<
-#
-# Function: words pgsql $PGHOST = p6df::modules::pgsql::profile::mod()
-#
-#  Returns:
-#	words - pgsql $PGHOST
-#
-#  Environment:	 PGHOST
-#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::deps()
-#
-#>
-######################################################################
 p6df::modules::pgsql::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6pgsql
@@ -15,11 +9,39 @@ p6df::modules::pgsql::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::pgsql::external::brews()
-#
-#>
+p6df::modules::pgsql::env::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@18"
+  p6_env_export "PKG_CONFIG_PATH" "$postgres_dir/lib/pkgconfig"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::pgsql::path::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@18"
+  p6_path_if "$postgres_dir/bin"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::pgsql::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-pgsql/share/.pgsqlrc" "$HOME/.pgsqlrc"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres"                                           "$HOME/.claude/skills/neon-postgres"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres-egress-optimizer"                         "$HOME/.claude/skills/neon-postgres-egress-optimizer"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/claimable-postgres"                                     "$HOME/.claude/skills/claimable-postgres"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/supabase/agent-skills/skills/supabase-postgres-best-practices"                           "$HOME/.claude/skills/supabase-postgres-best-practices"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::pgsql::external::brews() {
 
@@ -43,23 +65,41 @@ p6df::modules::pgsql::external::brews() {
 }
 
 ######################################################################
+p6df::modules::pgsql::mcp() {
+
+  p6_js_npm_global_install "@modelcontextprotocol/server-postgres"
+
+  p6df::modules::anthropic::mcp::server::add "postgres" "npx" "-y" "@modelcontextprotocol/server-postgres"
+  p6df::modules::openai::mcp::server::add "postgres" "npx" "-y" "@modelcontextprotocol/server-postgres"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::pgsql::profile::mod() {
+
+  p6_return_words 'pgsql' '$PGHOST'
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::pgsql::external::brews()
+#
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::pgsql::env::init()
 #
 #  Environment:	 HOMEBREW_PREFIX PKG_CONFIG_PATH
 #>
-######################################################################
-p6df::modules::pgsql::env::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@18"
-  p6_env_export "PKG_CONFIG_PATH" "$postgres_dir/lib/pkgconfig"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -68,35 +108,12 @@ p6df::modules::pgsql::env::init() {
 #  Environment:	 HOMEBREW_PREFIX
 #>
 ######################################################################
-p6df::modules::pgsql::path::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  local postgres_dir="$HOMEBREW_PREFIX/opt/postgresql@18"
-  p6_path_if "$postgres_dir/bin"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::pgsql::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::pgsql::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-pgsql/share/.pgsqlrc" "$HOME/.pgsqlrc"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres"                                           "$HOME/.claude/skills/neon-postgres"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/neon-postgres-egress-optimizer"                         "$HOME/.claude/skills/neon-postgres-egress-optimizer"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/neondatabase/agent-skills/skills/claimable-postgres"                                     "$HOME/.claude/skills/claimable-postgres"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/supabase/agent-skills/skills/supabase-postgres-best-practices"                           "$HOME/.claude/skills/supabase-postgres-best-practices"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -164,17 +181,6 @@ p6df::modules::pgsql::prompt::lang() {
 #
 #>
 ######################################################################
-p6df::modules::pgsql::mcp() {
-
-  p6_js_npm_global_install "@modelcontextprotocol/server-postgres"
-
-  p6df::modules::anthropic::mcp::server::add "postgres" "npx" "-y" "@modelcontextprotocol/server-postgres"
-  p6df::modules::openai::mcp::server::add "postgres" "npx" "-y" "@modelcontextprotocol/server-postgres"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: words pgsql $PGHOST = p6df::modules::pgsql::profile::mod()
@@ -184,9 +190,3 @@ p6df::modules::pgsql::mcp() {
 #
 #  Environment:	 PGHOST
 #>
-######################################################################
-p6df::modules::pgsql::profile::mod() {
-
-  p6_return_words 'pgsql' '$PGHOST'
-}
-


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None